### PR TITLE
Announce EdgeIX Beirut: Enhancing Lebanon’s Internet Exchange

### DIFF
--- a/messages/2025-05-13-introducing_edgeIX_beirut.md
+++ b/messages/2025-05-13-introducing_edgeIX_beirut.md
@@ -1,0 +1,69 @@
+---
+title: Announcing EdgeIX Beirut, Localizing Lebanon’s Internet Exchange
+description: Launching Lebanon’s first carrier-neutral Internet Exchange Point to localize traffic and dramatically improve internet performance.
+slug: introducing_EdgeIXBeirut
+authors: jud
+#image: https://i.imgur.com/mErPwqL.png
+hide_table_of_contents: true
+date: 2025-05-13T19:00:00Z
+---
+
+# Announcing EdgeIX Beirut: Localizing Lebanon’s Internet Exchange
+
+We initially envisioned EdgeIX as a program that provides grants, training, technical assistance, and equipment to set up micro-efficient IXs—neutral hubs where networks openly peer and enjoy low-cost colocation. The vision was to bring internet content and service providers together locally, enabling data to be exchanged within Lebanon instead of traversing distant overseas hubs.
+
+<!--truncate-->
+
+However, after extensive discussions with various stakeholders and recognizing the urgency and long-term value, we decided to take a more proactive approach. We are now directly initiating, operating, and maintaining EdgeIX Beirut, committing fully to this endeavor for the next 10 years.
+
+Our goal is for EdgeIX Beirut to become Lebanon’s first truly carrier-neutral Internet Exchange, significantly enhancing the nation’s internet infrastructure.
+
+## Why Lebanon Needs a Local IX
+
+Lebanon currently lacks any active IX, forcing local internet traffic to traverse international routes unnecessarily. The country’s previous two exchange points, including Beirut-IX launched in 2007, never scaled effectively and are now defunct. Consequently, even when Lebanese users access local content, the data frequently travels thousands of kilometers to Europe and back, typically via Marseille or Paris, just to reach a nearby network. Although major content providers have recently installed local caches, historically most traffic has been routed via Europe due to the national backbone (Ogero) primarily connecting there. Such indirect paths add substantial latency (\~50 milliseconds round-trip), degrade user experience, and inflate transit costs for ISPs.
+
+This challenge extends beyond Lebanon, reflecting a broader regional issue. Internet exchange infrastructure in the Middle East and Africa remains underdeveloped, resulting in excessive overseas routing, higher costs, and slower speeds. As of 2021, about 83% of Middle Eastern internet bandwidth was routed through Europe. Many countries rely on European exchange points like Frankfurt, London, Amsterdam, and Paris/Marseille, highlighting the stark performance gap compared to regions with established local IXs. Lebanon's situation, where even intra-country data loops through Europe, clearly demonstrates the critical need for a local IX.
+
+## The EdgeIX Solution: Open, Neutral, Micro-Efficient IXs
+
+EdgeIX represents P Foundation’s commitment to addressing this problem by establishing efficient, impactful IXs in underserved areas. Key features of EdgeIX Beirut include:
+
+- Grants & Equipment: Funding and donated hardware (switches, routers, etc.) to fully equip the exchange.
+- Training & Technical Assistance: Expert guidance on IX operations, BGP peering arrangements, and exchange management best practices.
+- Carrier-Neutral Colocation: A neutral, affordable facility for all network operators, ensuring no single ISP or telco dominates.
+- Open Peering Policy: Freely accessible peering for all participants, promoting maximum interconnection among ISPs, content providers, educational institutions, and others.
+- Micro-Efficiency: Compact, optimized infrastructure delivering high performance sustainably with minimal footprint and costs.
+
+EdgeIX Beirut brings the exchange closer to users, eliminating the need for Lebanese traffic to travel through distant hubs. This will dramatically reduce latency (by tens of milliseconds per packet) and significantly lower IP transit costs for local ISPs. Importantly, a neutral IX reduces dependency on any single upstream provider, enhancing the resilience of Lebanon’s internet connectivity.
+
+## Lebanon’s Chance to Catch Up
+
+Internet Exchange Points have long been integral to internet growth. Many global IXs began as community or academic projects, with the first established in 1988 at a university campus. These early IXs demonstrated the benefits of local interconnection: faster, cheaper access for everyone. Major tech hubs worldwide—such as Silicon Valley and Amsterdam—now thrive due to robust IXs handling substantial local traffic.
+
+However, the Middle East and Africa remain largely underserved in terms of IXs. Lebanon’s first attempt in 2007 at the American University of Beirut showed promise but faltered due to limited participation. Today, Lebanon still lacks a fully functional IX, exacerbating its digital divide through heavy dependence on international bandwidth. EdgeIX Beirut aims to transform this landscape, placing Lebanon firmly on the map of globally connected internet communities.
+
+We are confident this model works. For example, Kenya and Nigeria increased local traffic exchange from about 30% to 70% within eight years by developing strong IXs. Inspired by these success stories, our ambitious goal is to achieve over 70% local traffic exchange in Lebanon by Summer 2025. This means everything—from videos to financial transactions and academic resources—will reach users locally without leaving the country.
+
+_With EdgeIX Beirut, local ISPs and content providers will directly exchange traffic within Lebanon, significantly boosting speed, reliability, and efficiency._
+
+## EdgeIX Beirut Launch: Timeline and Expectations
+
+After extensive planning, EdgeIX Beirut is officially underway. Key milestones include:
+
+- **May 2025**: Establishing governance and technical setup through collaboration with local stakeholders.
+- **June 2025**: Hardware delivery and establishment of local fiber connectivity.
+- **July 2025**: Initial participation from 9 of Lebanon's 14 major ISPs (representing 40% of the market) and multiple content providers.
+- **Summer 2025**: Expanding participation to 13 of the 14 major ISPs.
+- **Beyond 2025**: Ongoing expansion, capacity upgrades, and gradual transition to community-led governance.
+
+For Lebanese internet users, these developments mean tangible improvements: faster website loading, smoother streaming, and lower latency in gaming. Local hosting will become viable, freeing up costly international bandwidth for essential overseas traffic.
+
+## Community Impact and Next Steps
+
+The launch of EdgeIX Beirut marks more than just a technical improvement—it is a community milestone. It unites telecom operators, private ISPs, universities, and content companies in enhancing Lebanon’s digital ecosystem. Localized traffic means faster, more affordable, and resilient internet, benefitting everything from business services to education tools. Critically, local peering ensures continued domestic connectivity even if international routes face disruptions.
+
+EdgeIX Beirut also serves as a pilot for broader regional expansion. Our mission at P Foundation is to foster a more equitable, distributed internet, enabling every community to fully engage in the global digital economy.
+
+We warmly invite all Lebanese ISPs, telecom carriers, content providers, and community networks to join EdgeIX Beirut. The benefits of local peering—lower latency, reduced costs, enhanced user experiences—are immediate and substantial. Regional and global partners interested in supporting or participating are also encouraged to connect.
+
+To learn more or to participate, contact us at [edgeix.beirut@p.foundation](mailto:edgeix.beirut@p.foundation).


### PR DESCRIPTION
Introduce EdgeIX Beirut as Lebanon's first carrier-neutral Internet Exchange Point, aiming to localize traffic and improve internet performance significantly. Highlight the benefits of local IXs and invite participation from ISPs and content providers.