### PR TITLE
Fix grammatical error in OpenIX description

### DIFF
--- a/OpenIX/01-about/index.md
+++ b/OpenIX/01-about/index.md
@@ -11,7 +11,7 @@ import DocCardList from '@theme/DocCardList';
 
 # OpenIX
 
-OpenIX Internet Exchange is a carrier-neutral, and data center-neutral interconnection platform that enables networks to efficiently exchange internet traffic.
+OpenIX Internet Exchange is a carrier-neutral interconnection platform that enables networks to efficiently exchange internet traffic.
 
 The following policy outlines the terms, conditions, and standards for connecting to and using OpenIX. All participants must adhere to these policies to maintain a secure, efficient, and fair peering environment. OpenIX is committed to international best practices and adheres strictly to local laws and regulatory requirements in each country where it operates.
 


### PR DESCRIPTION
Corrected a grammatical error in the OpenIX description for clarity.