### PR TITLE
Add Privacy Policy page and update footer links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -242,12 +242,16 @@ const config = {
         style: 'light',
         links: [
           {
-            label: 'Code of Conduct',
-            to: '/coc',
-          },
-          {
             label: 'AS399728',
             to: '/as399728',
+          },
+          {
+            label: 'Privacy Policy',
+            to: '/privacy',
+          },
+          {
+            label: 'Code of Conduct',
+            to: '/coc',
           },
           {
             label: 'Contact',

--- a/src/pages/privacy.md
+++ b/src/pages/privacy.md
@@ -1,0 +1,217 @@
+---
+title: P Foundation Privacy Policy
+description: P Foundation's Privacy Policy details the collection, use, and protection of your personal information, confirming we do not sell your data and adhere to US and international privacy standards.
+---
+
+# P Foundation Privacy Policy
+
+**Effective Date:** November 18, 2025
+
+## Introduction
+
+P Foundation (“**we**,” “**us**,” or “**our**”) is a nonprofit organization registered in Washington, DC (USA). We are committed to protecting your privacy. This Privacy Policy explains how we collect, use, store, and share personal information when you use our website (p.foundation) and any related mobile or web applications (collectively, our “**Services**”). It applies to all individuals who interact with P Foundation, including website visitors, donors, participants in our programs or services, newsletter subscribers, and users of our mobile applications. By using our Services, you acknowledge that you have read and understood this Privacy Policy. We adhere to applicable U.S. privacy laws and regulations (federal and state) and strive to follow best practices aligned with global standards such as the EU General Data Protection Regulation (GDPR).
+
+## Information We Collect
+
+**Personal Information:** We may collect various types of personal information from you, which can include:
+
+- **Contact Details:** Name, email address, postal address, phone number, or other basic contact information (for example, when you subscribe to our newsletter or register for an event).
+
+- **Donor Information:** If you donate to P Foundation, we collect information necessary to process the donation, such as the donation amount, billing address, and payment details. _Note:_ Payment card information (credit/debit card numbers, security codes) is typically collected directly by our third-party payment processor (e.g. Stripe) on our behalf for security; we do not store full credit card numbers on our servers.
+
+- **Account or Program Data:** If you sign up for an account or specific services/programs, we may collect information like your username, password, and any profile information or preferences you provide. This can also include information related to services you use or events you register for through our platform.
+
+- **Communication Preferences:** Records of your communication preferences (such as whether you opted-in to receive our newsletters or opted-out of certain communications).
+
+- **Usage Data:** Information about how you interact with our website and app. This includes: IP address, browser type, device identifiers, pages visited, date/time of visits, and other technical data. We also collect data through cookies and similar technologies as described below (e.g. browsing behavior on our site, referring webpages, and device information like operating system and app version for mobile users).
+
+- **Location Data:** General location information inferred from your IP address or provided by your device (for example, city or country). We do not collect precise GPS location unless you explicitly grant permission through a mobile app.
+
+- **Communication and Support Data:** If you contact us with questions or for support (for instance, via email or a contact form), we will collect the information you choose to provide in that correspondence (such as your inquiry and our response).
+
+- **Other Information You Provide Voluntarily:** Any other personal information you choose to provide to us (for example, if you fill out a survey, post a comment on our forums, or participate in a Foundation initiative that asks for information).
+
+We will only collect sensitive personal information (such as health or financial information beyond donation details) if it is necessary for a specific purpose **and** you have provided it voluntarily or as required by law. We do **not** intentionally collect any special categories of personal data unless you explicitly provide it.
+
+## How We Collect Information
+
+We collect personal information through several methods:
+
+- **Directly from You:** Most information is collected when you directly provide it to us. For example, we collect information when you fill out forms on our website (such as donation forms, subscription forms, contact/request forms, or event registration forms). Likewise, when you communicate with us (by email, phone, or in-person) or provide information in the course of using our services, we collect those details.
+
+- **Through Our Website and Apps (Automatically):** When you use our website or mobile applications, we automatically collect certain usage and device information. We use cookies, web beacons, and similar tracking technologies to gather data about your interactions with our Services (such as pages you visited, links clicked, or features used). This helps us understand how users navigate our content and enables certain functionalities like remembering your preferences. (See **Cookies and Tracking Technologies** below for more details.) We may also automatically receive device information from your phone or browser, such as IP address, device type, operating system, and app version, which is standard for web and app communications.
+
+- **From Third Parties:** We may receive information about you from third-party sources in some cases. For example, if you donate through a third-party fundraising platform or payment processor, that platform may forward us certain information to record and acknowledge your donation. If you register for our events via a partner organization, they might share registration details with us. We could also obtain updated contact information from service providers to keep our records current or receive referral information if someone recommends you for our programs. We treat any information obtained from third parties according to this Privacy Policy combined with any additional restrictions imposed by the source.
+
+- **Social Media or Linked Services:** If you engage with P Foundation on social media (for example, by following our pages or messaging us on platforms like Twitter, Facebook, or LinkedIn) or if you use social media credentials to log into our Services, we may receive certain information from those platforms according to their privacy policies. This might include your username, profile information, and any content you have made public. We will only use that information for the purposes consistent with this policy (for instance, responding to messages or connecting with our supporters).
+
+- **Cookies and Tracking Technologies:** We use cookies and similar technologies on our website to collect usage data and improve user experience. Cookies are small text files placed on your device that allow us to recognize your browser or device and remember your preferences. For example, we may use cookies to remember your language preference or other settings so you don’t have to re-enter them on each visit. Cookies also help us gather analytics about site traffic and engagement. We may use both first-party cookies (set by our site) and third-party cookies (set by analytics or embedded third-party tools). You can control or block cookies through your browser settings or through any cookie consent tool we provide (see **Your Rights and Choices** below for more on opting out). Note that some parts of our Services might not function properly if cookies are disabled.
+
+Most of the data we collect is not by itself directly identifying (like device or usage data), but it may be linked or combined with other information to identify you. We collect only what we need for the purposes described in this policy, and we do so in a lawful and fair manner. Where required by law or best practice, we will obtain your consent before collecting certain personal information (for instance, if local law deems certain analytics or cookies as requiring consent, or if we ever were to collect sensitive personal info).
+
+## How We Use Your Information
+
+We use personal information for the following purposes:
+
+- **To Provide and Improve Services:** We use the information to operate our website, mobile apps, and services. For example, we use personal data to create and manage user accounts, enable you to use features of our site/app, and to respond to your requests or inquiries. We may also use data to develop new features, improve the performance and usability of our Services, and personalize your experience (such as content recommendations or localized information).
+
+- **Donation Processing and Fundraising:** If you donate to P Foundation, we use your information to process your donation and for related activities. This includes using payment details to complete the transaction (via our secure payment processor), sending you a donation receipt or acknowledgment, and maintaining records of contributions for financial, auditing, and tax purposes. We may also use donor contact information to reach out about our fundraising campaigns, to express gratitude, or to inform you of the impact of your contribution. We _do not_ store full payment card numbers; payments are handled through compliant third-party processors as noted, and we ensure they meet strict security standards (such as PCI-DSS Level 1 compliance for handling credit card data)
+
+- **Communications and Updates:** We use your contact information (email, mailing address, or phone as appropriate) to send you communications that you have subscribed to or requested. For example, if you signed up for our newsletter or updates about our work, we will send you periodic emails about our programs, initiatives, and ways to get involved. If you are a donor or member of our community, we may send you important notices, thank-you letters, event invitations, or policy updates. You have control over marketing communications – see **Your Rights and Choices** for how to opt out of or modify your communication preferences at any time.
+
+- **Service Announcements and Administrative Messages:** We may send service-related announcements when necessary (e.g., if our website is temporarily down for maintenance, or to inform you of changes to this Privacy Policy or our Terms). These are non-promotional and typically you cannot opt out of these administrative communications, as they are important for the use of our Services.
+
+- **Analytics and Improvements:** We analyze usage data (including aggregated trends about how our users interact with our site and apps) to better understand how our Services are used. This helps us troubleshoot issues, perform research and analysis, and make improvements to layout, content, security, and features. For example, we might look at which pages are most visited or how users navigate the site to optimize the user experience. We may use third-party analytics tools (like Google Analytics or similar) that employ cookies and scripts to collect and analyze this information on our behalf. These analytics providers only receive pseudonymous information (such as device identifiers or truncated IP addresses) and are not allowed to use the data for their own unrelated purposes.
+
+- **Enforcing Policies and Protecting Rights:** We may use data to enforce our \[Code of Conduct\] and terms, to prevent fraud or misuse of our Services, and to ensure the security of our network and systems. For instance, we might use certain identifiers or logs to detect and mitigate malicious activities (like attempts to disrupt our network) or to control spam and abuse. If necessary, we will use personal information to investigate and take action against illegal or harmful activities, violations of our policies, or security incidents.
+
+- **Legal Compliance:** We may process and retain personal information as needed to comply with applicable laws, regulations, and our legal obligations. This includes maintaining records required by nonprofit regulations, honoring opt-out and data deletion requests as required by privacy laws, and responding to lawful requests by public authorities (such as court orders or subpoenas). If we are subject to any audits or reporting duties (for example, financial audits or government compliance for grants), relevant data may be used for those purposes as well.
+
+- **Other Purposes (with Notice/Consent):** If we intend to use your information for a purpose not listed above, we will provide specific notice to you and, if required, obtain your consent. For example, if we ever wanted to feature a supporter’s testimonial or share your story publicly, we would ask for your permission before doing so.
+
+We will not use personal data in ways that are incompatible with the purposes for which it was collected, unless we have your consent or are required/allowed by law to do so. We do **not** engage in selling your personal information to third parties for monetary gain or sharing it for their independent marketing purposes. Any sharing of data with third parties is done as described in the next section and only for the purposes outlined here (or as otherwise disclosed to you at the point of collection).
+
+## Data Sharing and Third-Party Disclosure
+
+We understand the importance of your privacy. We share personal information with others only in limited circumstances, and always with appropriate safeguards. The categories of third parties with whom we may share information include:
+
+- **Service Providers:** We employ trusted third-party companies and individuals to perform certain services on our behalf (“**processors**” or service providers). These include, for example:
+
+- **Payment Processors:** As noted, we use external payment processors (such as Stripe for online donations) to handle payment transactions securely. These processors will receive the necessary personal and payment information to process your donation or payment (like name, contact info, and credit card details) and are **not** permitted to use it for other purposes. They must comply with strict data security standards such as PCI-DSS for handling credit card data.
+
+- **Email and Newsletter Services:** If you subscribe to our newsletter or email updates, we may use an email marketing platform (for instance, Mailchimp, SendGrid, or similar services) to manage our mailing lists and send emails. These platforms store your email address (and name, if provided) for the purpose of sending communications on our behalf. They are contractually bound to protect your information and only process it according to our instructions.
+
+- **Cloud Hosting and IT Providers:** Our website, applications, and data are hosted on secure servers, which may be provided by third-party cloud infrastructure companies. These hosting providers may process stored data as needed for storage and retrieval, backup, and other IT support functions. We require that they maintain strong security practices to safeguard the data.
+
+- **Analytics Partners:** We may share some site/app usage data with analytics services as described in the previous section (e.g., Google Analytics). This information typically does not identify you personally and is used to provide us aggregate insights. Analytics partners are not allowed to use the data except to provide their services to us.
+
+- **Other Vendors:** We might also share information with other vendors who help us run our organization — for example, software providers (for customer relationship management, donor management, or event management), consultants or agencies assisting with outreach, or security service providers. In all cases, these parties are given only the information necessary for their function and are obligated to keep it confidential and secure. We have data processing agreements in place as appropriate to ensure they uphold privacy standards and use data only for our specified purposes.
+
+- **Partners and Affiliated Organizations:** P Foundation sometimes works with partner organizations, affiliates, or chapters to achieve our mission. If you participate in a joint event or program co-sponsored by P Foundation and a partner, we may share with that partner the information necessary to coordinate the event or follow up with you (for example, if you join a training session run jointly with another nonprofit, we might share attendee names and emails with them). We will let you know at the time of data collection if a program involves such sharing. Any partner with whom we share data will be expected to use it only for the purposes described (not for their own marketing unless you separately consent) and to protect it in accordance with applicable privacy laws.
+
+- **Legal Requirements and Protection:** We may disclose personal information to third parties if we, in good faith, believe such disclosure is necessary to:
+
+- Comply with a law, regulation, legal process, or enforceable governmental request (for example, to respond to a subpoena, court order, or an inquiry from law enforcement).
+
+- Enforce or apply our own terms of use or other agreements.
+
+- Protect the rights, property, or safety of P Foundation, our staff, our users, or the public. This can include exchanging information with other organizations for fraud prevention or to mitigate security vulnerabilities.
+
+- **Organizational Transfers:** In the unlikely event that P Foundation undergoes a major business transaction such as a merger, acquisition, reorganization, or transfer of all or a substantial part of our assets, personal information we have collected may be transferred to the succeeding entity as part of that transaction. If such a transfer occurs, we will ensure that your information remains protected by this Privacy Policy (or you are provided notice and an opportunity to opt out of any new uses or disclosures). We will also notify you via a prominent notice on our website or by email if any such change in ownership or control occurs and if it entails changes to the way your personal data is managed.
+
+- **With Your Consent:** Aside from the cases above, we will share your personal information with third parties only if you have given us explicit consent to do so. For example, if you ask us to introduce you to another organization, or if you agree that we can share your testimonial or story on our website or social media, we will share information in accordance with your request.
+
+**No Sale of Personal Data:** We do _not_ sell, rent, or trade your personal information to third parties for their own marketing purposes. We also do not share donor or subscriber lists with other organizations for independent use without your permission. Any sharing that occurs is limited to the scenarios outlined above and primarily to facilitate our operations or comply with the law.
+
+**Third-Party Websites and Content:** Our Services may include links to third-party websites or content (for example, a news article, partner website, or social media feature). If you click those links, you will be directed to sites that we do not operate. This Privacy Policy does not govern those external sites. We recommend you review the privacy policies of any third-party website or service you visit, as their practices are outside our control. We are not responsible for the privacy practices or content of such third-party sites.
+
+## Data Storage and Security
+
+P Foundation takes reasonable and appropriate measures to secure personal information and protect it from unauthorized access, alteration, loss, or disclosure. We have implemented a range of administrative, technical, and physical safeguards in line with industry standards and legal requirements. These measures include, for example:
+
+- **Encryption:** Sensitive information (such as financial data) is transmitted over secure sockets layer (SSL/TLS) encrypted connections. Where applicable, we also encrypt certain data at rest.
+
+- **Access Controls:** Personal data is stored on systems that have controlled access. Only authorized P Foundation personnel, contractors, or service providers who need the data to perform their duties have access. They are required to keep information confidential. We implement authentication measures (such as passwords and, where appropriate, multi-factor authentication) to prevent unauthorized access to accounts and our systems.
+
+- **Security Practices of Processors:** We choose reputable service providers and require them to uphold strong security practices. For example, our payment processing partners adhere to PCI-DSS standards for handling credit card information, and our hosting providers maintain high levels of security certifications. We also seek assurances such as confidentiality agreements and data processing agreements from our vendors.
+
+- **Monitoring and Testing:** We monitor our systems for possible vulnerabilities and attacks, and we periodically review our practices to address new threats. Security updates and patches are applied to our software and infrastructure regularly. Where feasible, we conduct testing (such as penetration testing or vulnerability scans) to proactively identify risks.
+
+- **Staff Training and Policies:** Our team members are trained on data privacy and security principles. We have internal policies in place to prevent unauthorized sharing of user information and to handle personal data with care and respect.
+
+Despite our best efforts, please note that **no method of transmission over the internet or method of electronic storage is 100% secure**. Therefore, while we strive to protect your personal information, we cannot guarantee absolute security. In the event of a data breach or security incident that compromises your personal data, we will notify you and any relevant regulatory bodies as required by law. We comply with all applicable data breach notification laws, including those of the District of Columbia, which mandate notifying affected individuals (and regulators, if applicable) in a timely manner if personal information is involved in a security breach.
+
+**Data Retention:** We retain personal information only for as long as necessary to fulfill the purposes outlined in this Privacy Policy, unless a longer retention period is required or permitted by law. For example, we may retain: (a) donation and transaction records to comply with accounting, tax, and charitable reporting obligations; (b) contact information for as long as you are subscribed to our communications (and not opted-out); (c) user account information while your account is active and for a reasonable period thereafter in case you return or as needed to comply with legal obligations. When we no longer have a legitimate need or legal requirement to retain your personal information, we will securely delete or anonymize it. If deletion is not immediately possible (for example, because the data is stored in backup archives), we will ensure it remains securely stored and isolated from further use until deletion is feasible.
+
+## Your Rights and Choices
+
+We believe in transparency and giving you control over your personal information. Depending on applicable law and your location, you have certain rights and choices regarding how your data is used. We honor the following rights and provide mechanisms for you to exercise them:
+
+- **Access and Correction:** You have the right to request access to the personal information we hold about you and to receive an explanation of how we use it. You may also request corrections or updates to any inaccurate or incomplete personal data. For example, if you have an account with us, you can log in and update certain profile information directly. Otherwise, you can contact us (see **Contact Us** below) to request that we update or correct your data.
+
+- **Deletion (Right to Erasure):** You can request that we delete your personal information, subject to certain exceptions. Upon your request, we will remove or anonymize the personal data we hold about you to the extent required by applicable law. (For instance, we may need to keep certain donation records for audit or tax purposes, or we may retain data as necessary to exercise or defend legal claims.) If you have publicly posted content on our site (such as comments in a forum), we may not be able to delete past posts you made, but we can delete personal data associated with your account upon request and will do so insofar as it’s within our control.
+
+- **Withdrawal of Consent:** If we process your personal information based on your consent (for example, if you gave consent to receive our newsletter or for a specific optional feature), you have the right to withdraw that consent at any time. Withdrawing consent will not affect the lawfulness of any processing we conducted prior to your withdrawal, and it may mean we can no longer provide certain services to you. For instance, if you withdraw consent to receive our communications, we will stop sending you the newsletter or updates.
+
+- **Opt-Out of Marketing Communications:** You may unsubscribe from our email newsletter or promotional emails at any time by clicking the “unsubscribe” link in the footer of those emails or by contacting us. Once you opt out, we will not send you further marketing emails, though we may still send you essential administrative or transactional messages (such as donation receipts or service notifications). You can also let us know if you prefer not to receive other forms of communication, like postal mail or phone calls, and we will respect those preferences where feasible.
+
+- **Opt-Out of Cookies/Tracking:** As discussed in the Cookies section, you can control or delete cookies through your browser settings. You can also use opt-out options provided by some third-party analytics or advertising partners. For example, Google Analytics offers a browser add-on to opt-out of its tracking. If we use any cookies that require consent under applicable law, we will obtain consent via a banner or settings tool when you first visit our site. Even if not required, we provide you the ability to refuse non-essential cookies. Please note that blocking cookies might impact the functionality of the Services.
+
+- **Do Not Track:** Some browsers have “Do Not Track” (DNT) features that send a signal to websites indicating you do not want to be tracked. Currently, there is no universal standard for how to interpret DNT signals. While our systems may not respond to every DNT signal, we treat all users’ data in accordance with this Privacy Policy and encourage you to use other opt-out methods described here.
+
+- **Non-Discrimination:** We will not discriminate against you for exercising any of these privacy rights. For example, we will not deny you services, charge you a different price, or provide a different level of service because you exercised your rights. If you request deletion of data necessary for us to provide a service, we will inform you if we can no longer provide that service (and give you the choice to retract the deletion request if you wish).
+
+To exercise any of your rights described above, please contact us using the information in the **Contact Us** section. We may need to verify your identity before fulfilling certain requests (for instance, to ensure that we do not disclose data to the wrong person). Verification might involve asking you to provide information that matches our records or other proof of identity. We will respond to legitimate requests within the timeframe required by law (for example, under some laws we have up to 30 or 45 days to respond, with the possibility of a reasonable extension). There is typically no fee for making a request, but if your requests are manifestly unfounded or excessive (e.g., repetitive), we may charge a reasonable fee or refuse to comply as allowed by law. We will notify you of any such decision.
+
+### California Privacy Rights
+
+While P Foundation is a nonprofit organization (and the California Consumer Privacy Act, _as amended by_ the California Privacy Rights Act, **collectively “CCPA”**, generally applies to for-profit businesses), we value the privacy rights of all our supporters, including California residents. Therefore, we voluntarily provide the following disclosures and rights to California residents, in alignment with the spirit of the CCPA:
+
+**Notice of Information Practices:** In the preceding 12 months, P Foundation **has collected** the categories of personal information described in the **“Information We Collect”** section of this policy (such as identifiers like name and email, payment information, internet or device activity, etc.). We collect these categories for the purposes described in **“How We Use Your Information.”** We do **not** sell personal information to third parties, and we have not done so in the past 12 months. We also do not share personal information for cross-context behavioral advertising (and do not serve targeted advertising in our Services at this time). Because we do not sell or share personal data in those ways, we do not include a “Do Not Sell or Share My Personal Information” opt-out link on our website. We also do not use or disclose sensitive personal information for purposes that California law would limit (other than for the purposes it was provided, such as processing a donation).
+
+**California Consumer Rights:** If you are a California resident, you have certain legal rights under the CCPA regarding your personal information, including:  
+\- _Right to Know:_ You may request that we disclose what personal information we collect, use, or disclose about you. This includes the specific pieces of information we have about you, as well as information about the categories of personal info, the categories of sources of that info, the business or commercial purpose for collecting it, and the categories of third parties with whom we share it.  
+\- _Right to Delete:_ You may request that we delete personal information we have collected from you (subject to the exceptions noted in the **Your Rights and Choices** section above and as allowed by law).  
+\- _Right to Correct:_ You may request that we correct inaccurate personal information that we maintain about you.  
+\- _Right to Opt-Out of Sale/Sharing:_ As noted, we do not sell personal data or share it for targeted advertising. If that ever changes, we will update this policy and provide a clear opt-out mechanism.  
+\- _Right to Non-Discrimination:_ We will not retaliate or discriminate against you for exercising any of these rights (as already stated).
+
+If you are a California resident and would like to exercise any of these rights, please contact us (see **Contact Us** below). We will verify your request as required (which may involve confirming details we have on file about you). If you designate an authorized agent to make a request on your behalf, we will take steps to verify the agent’s authority and may still ask you to verify your identity directly with us.
+
+Additionally, California’s “Shine the Light” law (Civil Code § 1798.83) allows residents to ask companies with whom they have an established business relationship what types of personal information, if any, the company has shared with third parties for those third parties’ direct marketing purposes in the preceding year. We do **not** disclose personal information to third parties for their own direct marketing purposes without your consent. Thus, we believe we have no disclosure obligations under that law. If you have questions about this, you may contact us to learn more.
+
+### Children’s Privacy (COPPA)
+
+Our Services are **not directed to children under the age of 13**, and we do not knowingly collect personal information from children under 13 years old. In accordance with the U.S. Children’s Online Privacy Protection Act (COPPA) and similar laws, if we become aware that we have inadvertently collected personal information from a child under 13 without verifiable parental consent, we will take immediate steps to delete that information from our records. If you are a parent or guardian and you believe that your child under 13 may have provided personal information to us, please contact us right away so that we can investigate and address the issue.
+
+Teenagers between 13 and 18 years of age may use our Services with the involvement of a parent or guardian (for example, a teen might engage in a youth program or subscribe to updates). However, if you are under 18, please ensure that you have your parent or guardian’s permission before providing any personal information to us. Some jurisdictions provide specific rights for minors; for instance, under California law, minors under 18 who are registered users of online sites can request removal of content they post. If applicable, we will honor such rights. If you are under 18 and have posted content on our site that you cannot remove, you may contact us to request removal (though note that removal may not be comprehensive if others have re-posted the content).
+
+## International Data Transfers
+
+P Foundation is based in the United States, and our website and infrastructure are primarily hosted in the U.S. If you are accessing our Services from outside the United States, please be aware that your personal information will likely be transferred to, stored, and processed in the United States or other jurisdictions where our service providers are located. Data protection laws in these countries may differ from those in your home country.
+
+However, regardless of where your data is processed, we will protect it as described in this Privacy Policy and in accordance with applicable law. If you are in the European Economic Area (EEA), United Kingdom, or another region with laws governing data collection and use that differ from U.S. law, we ensure that appropriate safeguards are in place to legitimize data transfers. This may include using standard contractual clauses approved by the European Commission, relying on the service providers’ certifications or binding corporate rules, or other lawful mechanisms. We only transfer personal data internationally in compliance with those data protection laws.
+
+### GDPR and International Privacy Rights
+
+If you are an individual located in the EEA, UK, or Switzerland, you are entitled to additional rights under the GDPR and analogous data protection laws. These may include:
+
+- **Right to Access:** You can ask us to confirm if we are processing your personal data and request a copy of that data (which we will provide in a commonly used electronic format).
+
+- **Right to Rectification:** You can request that we correct any inaccurate or incomplete personal data about you.
+
+- **Right to Erasure:** Under certain conditions, you have the right to request deletion of your personal data (“right to be forgotten”), similar to the deletion rights described earlier.
+
+- **Right to Restrict Processing:** You can ask us to restrict or suspend the processing of your personal data in certain circumstances (for example, if you contest the accuracy of the data or object to us processing it on the basis of our legitimate interests, we will consider the request and inform you of the outcome).
+
+- **Right to Data Portability:** You have the right, in certain cases, to obtain the personal data you provided to us in a structured, commonly used, machine-readable format, and to transmit it to another data controller. This typically applies when processing is based on consent or contract and carried out by automated means.
+
+- **Right to Object:** You may object to our processing of your personal data if we are processing it based on legitimate interests or for direct marketing. If you object to direct marketing, we will cease processing your data for those purposes. If you object on grounds relating to your particular situation to processing based on legitimate interests, we will evaluate your objection and will stop processing the data unless we have compelling legitimate grounds or need to continue for legal reasons.
+
+- **Right not to be subject to Automated Decisions:** We do not use personal data to make decisions that have legal or similarly significant effects on you solely by automated means (without human involvement). However, if we ever did, you would have the right not to be subject to such decisions under certain conditions.
+
+- **Right to Withdraw Consent:** If we rely on consent for any processing, you can withdraw that consent at any time (as noted in the general rights section).
+
+- **Right to Lodge a Complaint:** European and other international users have the right to lodge a complaint with a supervisory authority if you believe our processing of your personal data violates applicable law. For EU residents, this would typically be the data protection authority in your country or the country where the alleged infringement occurred. We would appreciate the chance to address your concerns before you do this, so please consider reaching out to us first.
+
+To exercise any of these international rights, you can contact us (see **Contact Us** below). We will handle requests in accordance with applicable data protection laws. For instance, GDPR requires us to respond within one month unless an extension applies. We may ask for additional information to verify identity, as described earlier.
+
+Our legal bases for processing personal data (as per GDPR) usually include: your consent (for example, sending newsletters), performance of a contract (providing services you requested), compliance with a legal obligation (retaining donation records for tax, or responding to legal processes), and our legitimate interests (such as improving our services, network security, and pursuing our nonprofit mission, balanced against your rights and expectations). We will clarify the specific legal bases upon request or when required.
+
+## Changes to This Privacy Policy
+
+We may update this Privacy Policy from time to time to reflect changes in our practices, technologies, legal requirements, or other factors. When we make changes, we will revise the “Effective Date” at the top of this policy. If the changes are significant, we will provide a more prominent notice (such as a banner on our website or an email notification of the update). We encourage you to review this Privacy Policy periodically to stay informed about how we are protecting your information.
+
+Your continued use of our Services after any modifications to the Privacy Policy will constitute your acknowledgment of the changes and agreement to abide by the updated policy, to the extent permitted by law. If we seek to use your personal information for a new purpose that is not compatible with the purposes we collected it for, we will obtain your consent if required or provide you with an opportunity to opt out.
+
+## Contact Us
+
+P Foundation is responsible for the processing of your personal information as described in this policy. If you have any questions, concerns, or requests regarding this Privacy Policy or your personal data, please contact us:
+
+- **Email:** privacy@p.foundation
+- **Postal Mail:** P Foundation – Privacy Inquiry  
+  700 12th St NW, Ste 700, Washington, DC 20005, United States
+
+We are committed to resolving any complaints or disputes regarding the use of your personal information. If you contact us with a privacy concern, we will do our best to address it promptly and fairly. If you feel we have not adequately answered your questions or concerns, you may have the right to contact your local data protection authority (as noted in the GDPR section for EU users) or other regulators.
+
+Thank you for trusting P Foundation with your personal information. We value your support and are dedicated to protecting your privacy while furthering our mission of open internet access and free journalism for the public good.


### PR DESCRIPTION
Introduce a Privacy Policy page and reorganize footer links to include the new policy while maintaining the existing Code of Conduct link.