### PR TITLE
Embed OpenIX Beirut traffic dashboard in traffic statistics page

### DIFF
--- a/OpenIX/01-beirut/03-traffic.md
+++ b/OpenIX/01-beirut/03-traffic.md
@@ -5,6 +5,31 @@ description: OpenIX Beirut Traffic Statistics
 
 # Traffic Statistics
 
-:::note
+<>
 
-Content is currently not available.
+  <div
+    style={{
+      boxSizing: 'border-box',
+      width: '100%',
+      maxWidth: '2560px',
+      border: '1px solid #e2e8f0',
+      borderRadius: '12px',
+      boxShadow:
+        '0px 0px 1px rgba(45, 55, 72, 0.05), 0px 4px 8px rgba(45, 55, 72, 0.1)',
+      overflow: 'hidden',
+    }}
+  >
+    <iframe
+      src="https://grafana.openix.ong/public-dashboards/cd77af8dbb64458db265874b0347afd6"
+      title="OpenIX Beirut Traffic"
+      loading="lazy"
+      scrolling="auto"
+      style={{
+        display: 'block',
+        width: '100%',
+        minHeight: '1700px',
+        border: '0',
+      }}
+    />
+  </div>
+</>


### PR DESCRIPTION
Integrate the OpenIX Beirut traffic dashboard into the traffic statistics page, enhancing the visibility of traffic data.