### PR TITLE
Standardize quotes and update folder path in PR build workflow

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -73,5 +73,5 @@ jobs:
           file-extension: '.md'
           check-modified-files-only: 'yes'
           config-file: '.mlc.config.json'
-          folder-path: 'blog, messages, src/pages'
+          folder-path: 'blog, updates, src/pages'
           base-branch: 'master'


### PR DESCRIPTION
Standardize the use of quotes and replace the folder path from 'messages' to 'updates' in the PR build workflow configuration.