### PR TITLE
feat: add observability logging configuration to wrangler.toml

### DIFF
--- a/workers/wrangler.toml
+++ b/workers/wrangler.toml
@@ -24,6 +24,10 @@ MAILGUN_DOMAIN = "bounce.p.foundation"
 MAILGUN_API_BASE = "https://api.mailgun.net"
 SITE_URL = "https://p.foundation"
 
+[observability.logs]
+enabled = true
+invocation_logs = true
+
 # Per IP rate limiting: 10 requests per minute per endpoint. The Workers rate
 # limiting API uses the "unsafe" bindings namespace while in beta. The worker
 # code treats the binding as optional, so if a deploy rejects this block you


### PR DESCRIPTION
Enable invocation logging for workers observability by adding the logs configuration section with enabled and invocation_logs flags set to true.