### PR TITLE
Remove OpenCache mention from OpenIX landing page

### DIFF
--- a/OpenIX/00-OpenIX.mdx
+++ b/OpenIX/00-OpenIX.mdx
@@ -15,8 +15,6 @@ OpenIX Internet Exchange is a carrier-neutral interconnection platform that enab
 
 <IxStats />
 
-[OpenCache](/opencache), the P Foundation's open caching network, is live at the exchange, allowing peering networks to reach cached content over local peering.
-
 The following policy outlines the terms, conditions, and standards for connecting to and using OpenIX. All participants must adhere to these policies to maintain a secure, efficient, and fair peering environment. OpenIX is committed to international best practices and adheres strictly to local laws and regulatory requirements in each country where it operates.
 
 ## Governance and Organizational Structure


### PR DESCRIPTION
Eliminate the reference to OpenCache on the OpenIX landing page to streamline the content and focus on the core offerings of the platform.